### PR TITLE
validate array of child objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/bin
 /.bundle/
 /.yardoc
 /Gemfile.lock

--- a/.rubocop-https---raw-githubusercontent-com-sage-s1-linter-config-master--rubocop-yml
+++ b/.rubocop-https---raw-githubusercontent-com-sage-s1-linter-config-master--rubocop-yml
@@ -1,0 +1,384 @@
+# Up to date as of v0.54.0
+# If a cop is not referenced here, the defaults from Rubocop will be used.
+
+AllCops:
+  Exclude:
+    - '**/db/**/*'
+    - '**/tmp/**/*'
+    - '**/vendor/**/*'
+    - '**/script/**/*'
+  DisplayStyleGuide: true
+  ExtraDetails: true
+  UseCache: true
+  MaxFilesInCache: 50000
+  TargetRubyVersion: 2.3
+  TargetRailsVersion: 4.2
+
+# Always use alias_method when aliasing methods of modules, classes, or singleton classes at runtime, as the lexical
+# scope of alias leads to unpredictability in these cases.
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+# Checks for cases when you could use a block accepting version of a method that does automatic resource cleanup.
+#
+#   # bad
+#   f = File.open('file')
+#
+#   # good
+#   f = File.open('file') do
+#     ...
+#   end
+Style/AutoResourceCleanup:
+  Enabled: true
+
+# Checks if usage of %() or %Q() matches configuration.
+#
+# EnforcedStyle: percent_q - enforces use of %Q().
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+# Checks the style of children definitions at classes and modules. Basically there are two different styles:
+#
+# EnforcedStyle:
+#   nested - have each child on its own line
+#     class Foo
+#       class Bar
+#       end
+#     end
+#
+# compact (allowed for specs only) - combine definitions as much as possible
+#   class Foo::Bar
+#   end
+Style/ClassAndModuleChildren:
+  Exclude:
+    - '**/spec/**/*'
+
+# Mapping from undesired method to desired method e.g. to use `detect` over `find`.
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'detect'
+    find_all: 'select'
+
+# This cop checks for missing top-level documentation of classes and modules. Classes with no body are exempt from the
+# check and so are namespace modules - modules that have nothing in their bodies except classes, other modules, or
+# constant definitions.
+#
+# The documentation requirement is annulled if the class or module has a "#:nodoc:" comment next to it. Likewise,
+# "#:nodoc: all" does the same for all its children.
+Style/Documentation:
+  Exclude:
+    - '**/spec/**/*'
+
+# Warn on empty else statements
+#
+# EnforcedStyle: empty - only return an error for a completely empty else clause as sometimes it may be necessary to
+# return `nil` from an else branch.
+Style/EmptyElse:
+  EnforcedStyle: empty
+
+# Checks for the formatting of empty method definitions.
+#
+# EnforcedStyle: expanded - only return an error if the end is on the same line as the def.
+#
+# bad
+# def foo(bar); end
+#
+# good
+# def foo(bar)
+# end
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+  Exclude:
+    - '**/spec/**/*'
+
+# Checks for methods called on a do...end block. The point of this check is that it's easy to miss the call tacked on
+# to the block when reading code.
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+
+# Checks for `if` / `case` expressions that do not have an `else` branch.
+#
+# Only configured to check for `case` statements. It's best practice to always provide a default for `case` statements.
+Style/MissingElse:
+  Enabled: true
+  EnforcedStyle: case
+
+# Use `next` to skip iteration instead of a condition at the end.
+#
+# # bad
+# [1, 2].each do |a|
+#   if a == 1 do
+#     puts a
+#   end
+# end
+#
+# # good
+# [1, 2].each do |a|
+#   next unless a == 1
+#
+#   puts a
+# end
+Style/Next:
+  EnforcedStyle: always
+
+# Checks for options hashes and discourages them if the current Ruby version supports keyword arguments.
+Style/OptionHash:
+  Enabled: true
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    '%i': '()'
+    '%I': '()'
+    '%w': '()'
+    '%W': '()'
+
+# Checks for the use of the send method. Prefers use of `__send__` and `public_send` over `send`.
+Style/Send:
+  Enabled: true
+
+# Enforces the use of consistent method names from the String class. So far it enforces use of `to_sym` over `intern`.
+Style/StringMethods:
+  Enabled: true
+
+# Check for array literals made up of symbols that are not using the %i() syntax.
+Style/SymbolArray:
+  Enabled: true
+  EnforcedStyle: brackets
+
+# Checks for the presence of parentheses around ternary conditions.
+#
+# EnforcedStyle: require_parentheses_when_complex
+#
+# bad
+# foo = (bar?) ? a : b
+# foo = (bar.baz?) ? a : b
+# foo = bar && baz ? a : b
+#
+# good
+# foo = bar? ? a : b
+# foo = bar.baz ? a : b
+# foo = (bar && baz) ? a : b
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+
+#################### Layout ################################
+
+# Align the elements of a hash literal if they span more than one line.
+#
+# EnforcedHashRocketStyle: key - left alignment of keys.
+#   'a' => 2
+#   'bb' => 3
+#
+# EnforcedColonStyle: key - left alignment of keys.
+#   a: 0
+#   bb: 1
+Layout/AlignHash:
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+
+# Alignment of parameters in multi-line method calls.
+#
+# The `with_fixed_indentation` style aligns the following lines with one level of indentation relative to the start of
+# the line with the method call.
+#
+#     method_call(a,
+#       b)
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+# Checks how the whens of a case expression are indented in relation to its end keyword.
+#
+# EnforcedStyle: end
+#
+# good
+# kind = case year
+# when 1850..1889
+#   'Blues'
+# when 1890..1909
+#   'Ragtime'
+# when 1910..1929
+#   'New Orleans Jazz'
+# when 1930..1939
+#   'Swing'
+# when 1940..1950
+#   'Bebop'
+# else
+#   'Jazz'
+# end
+Layout/CaseIndentation:
+  EnforcedStyle: end
+  
+# Checks whether the end keywords are aligned properly.
+#
+# AlignWith: variable - in assignments, `end` should be aligned with the start of the variable on the left hand side of
+# `=`. In all other situations, `end` should still be aligned with the keyword.
+#
+# variable = if true
+# end
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+
+# Checks for a line break before the first element in a multi-line array.
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+# Checks for a line break before the first element in a multi-line hash.
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+# Checks for a line break before the first argument in a multi-line method call.
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+# Checks for a line break before the first parameter in a multi-line method parameter definition.
+Layout/FirstMethodParameterLineBreak:
+  Enabled: true
+
+# Checks the indentation of the first element in an array literal.
+#
+# The value `consistent` means that the indentation of the first element shall always be relative to the first position
+# of the line where the opening bracket is.
+#
+# array = [
+#   :value
+# ]
+# and_in_a_method_call([
+#   :no_difference
+# ])
+Layout/IndentFirstArrayElement:
+  EnforcedStyle: consistent
+
+# Checks the indentation of the first key in a hash literal.
+#
+# The value `consistent` means that the indentation of the first key shall always be relative to the first position
+# of the line where the opening brace is.
+#
+# hash = {
+#   key: :value
+# }
+# and_in_a_method_call({
+#   no: :difference
+# })
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent
+
+# Checks that multiline assignments do not have a newline after the assignment operator.
+#
+# EnforcedStyle: same_line
+#
+# foo = if expression
+#   'bar'
+# end
+Layout/MultilineAssignmentLayout:
+  Enabled: true
+  EnforcedStyle: same_line
+
+# Checks the indentation of the method name part in method calls that span more than one line.
+#
+# EnforcedStyle: indented
+#
+# Thing.a
+#   .b
+#   .c
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+# Checks the indentation of the right hand side operand in binary operations that span more than one line.
+#
+# EnforcedStyle: indented
+#
+# if a &&
+#     b
+#   something
+# end
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+#################### Naming ##########################
+
+# Checks that all numbered variables use the configured style for their numbering.
+#
+# EnforcedStyle: snake_case
+#
+# # bad
+#
+# variable1 = 1
+#
+# # good
+#
+# variable_1 = 1
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
+#################### Metrics ################################
+
+# Checks that the ABC size of methods is not higher than the configured maximum. The ABC size is based on assignments,
+# branches (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric.
+Metrics/AbcSize:
+  Max: 22
+
+# This cop checks if the length of a block exceeds some maximum value. Ignores comment-only lines.
+Metrics/BlockLength:
+  Exclude:
+    - '**/routes.rb'
+    - '**/config/initializers/**/*.rb'
+    - '**/config/environments/**/*.rb'
+    - '**/spec/**/*'
+    - '**/*.gemspec'
+
+# Checks if the length a class exceeds some maximum value. Ignores comment-only lines.
+Metrics/ClassLength:
+  Max: 150
+
+# Checks that the cyclomatic complexity of methods is not higher than the configured maximum. The cyclomatic complexity
+# is the number of linearly independent paths through a method. The algorithm counts decision points and adds one.
+#
+# An if statement (or unless or ?:) increases the complexity by one. An else branch does not, since it doesn't add a
+# decision point. The && operator (or keyword and) can be converted to a nested if statement, and ||/or is shorthand for
+# a sequence of ifs, so they also add one. Loops can be said to have an exit condition, so they add one.
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+# Checks the length of lines in the source code.
+Metrics/LineLength:
+  Max: 120
+  Exclude:
+    - '**/routes.rb'
+    - '**/config/initializers/**/*.rb'
+    - '**/config/environments/**/*.rb'
+    - '**/Gemfile'
+
+# Checks if the length of a method exceeds some maximum value. Ignores comment-only lines.
+Metrics/MethodLength:
+  Max: 20
+  Exclude:
+    - '**/spec/**/*'
+
+# Checks if the length of a module exceeds some maximum value. Ignores comment-only lines.
+Metrics/ModuleLength:
+  Max: 100
+
+# Tries to produce a complexity score that's a measure of the complexity the reader experiences when looking at a
+# method. For that reason it considers `when` nodes as something that doesn't add as much complexity as an `if` or a
+# `&&`. Except if it's one of those special `case`/`when` constructs where there's no expression after `case`. Then
+# the cop treats it as an `if`/`elsif`/`elsif`... and lets all the `when` nodes count. In contrast to
+# CyclomaticComplexity, it considers `else` nodes as adding complexity.
+Metrics/PerceivedComplexity:
+  Max: 7
+
+#################### Lint ################################
+
+# Checks for assignments in the conditions of if/while/until.
+Lint/AssignmentInCondition:
+  AllowSafeAssignment: false
+
+# Checks for interpolated literals.
+#
+# "result is #{10}"
+Lint/LiteralInInterpolation:
+  AutoCorrect: true

--- a/.rubocop-local-overrides.yml
+++ b/.rubocop-local-overrides.yml
@@ -1,0 +1,12 @@
+#################### Style ##########################
+
+# Disabled due to them adding little value
+Style/Documentation:
+  Enabled: false
+
+##################### Lint ##########################
+
+# Allow un-used keyword arguments
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: true
+  IgnoreEmptyMethods: true

--- a/.rubocop-shared.yml
+++ b/.rubocop-shared.yml
@@ -1,0 +1,2 @@
+inherit_from:
+  - 'https://raw.githubusercontent.com/sage/s1_linter_config/master/.rubocop.yml'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_from:
+  - '.rubocop-shared.yml'
+  - '.rubocop-local-overrides.yml'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ruby:2.3-alpine
+
+RUN apk add --no-cache --update bash
+
+RUN apk add --no-cache --update --virtual .gem-builddeps make gcc libc-dev ruby-json \
+    && gem install -N oj -v 2.15.0 \
+    && gem install -N json -v 2.2.0 \
+    && gem install -N byebug -v 11.0.1 \
+    && apk del .gem-builddeps
+
+# Create application directory and set it as the WORKDIR.
+ENV APP_HOME /validation_profiler
+RUN mkdir -p $APP_HOME
+WORKDIR $APP_HOME
+
+COPY . $APP_HOME
+
+RUN bundle install --system --binstubs

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,9 @@
 source 'http://rubygems.org'
 
+gem 'json', '2.2.0'
+
+gem 'byebug'
+gem 'pry-byebug'
+
 # Specify your gem's dependencies in validation_profiler.gemspec
 gemspec
-

--- a/lib/validation_profiler/manager.rb
+++ b/lib/validation_profiler/manager.rb
@@ -1,6 +1,5 @@
 module ValidationProfiler
   class Manager
-
     # Called to validate an object against a validation profile.
     #
     # @param obj [Object] The object to validate
@@ -8,33 +7,32 @@ module ValidationProfiler
     #
     # @return [ValidationManagerResult] The result of the validation
     def validate(obj, profile, parent = nil)
-
       result = ValidationProfiler::ManagerResult.new
 
       validation_rules = profile.class_variable_get(:@@validation_rules)
 
       validation_rules.each do |r|
 
-        if ValidationProfiler::Rules::Manager.instance == nil
+        if ValidationProfiler::Rules::Manager.instance.nil?
           ValidationProfiler::Rules::Manager.new
         end
 
         rule = ValidationProfiler::Rules::Manager.instance.get_rule(r[:name])
         outcome = rule.validate(obj, r[:field], r[:attributes], parent)
 
-        if outcome.is_a?(ValidationProfiler::ManagerResult) && !outcome.outcome
+        if outcome.is_a?(Array)
+          result.errors = outcome.map(&:errors).flatten
+          result.outcome = result.errors.empty?
+        elsif outcome.is_a?(ValidationProfiler::ManagerResult) && !outcome.outcome
           result.errors = result.errors + outcome.errors
           result.outcome = false
         elsif !outcome
           result.outcome = false
-          result.errors.push({ field: r[:field], message: rule.error_message(r[:field], r[:attributes], parent) })
+          result.errors.push(field: r[:field], message: rule.error_message(r[:field], r[:attributes], parent))
         end
-
       end
 
       result
-
     end
-
   end
 end

--- a/lib/validation_profiler/rules/child_validation_rule.rb
+++ b/lib/validation_profiler/rules/child_validation_rule.rb
@@ -1,17 +1,14 @@
 module ValidationProfiler
   module Rules
+    # Validation rule for child attributes
     class ChildValidationRule < ValidationProfiler::Rules::ValidationRule
-
       def error_message(field, attributes = {}, parent = nil)
-
         field_name = field.to_s
-        if parent != nil
-          field_name = "#{parent.to_s}.#{field.to_s}"
-        end
+        field_name = "#{parent}.#{field}" unless parent.nil?
 
-        #check if a custom error message has been specified in the attributes
-        if attributes[:message] == nil
-          #no custom error message has been specified so create the default message.
+        # check if a custom error message has been specified in the attributes
+        if attributes[:message].nil?
+          # no custom error message has been specified so create the default message.
           "#{field_name} is required."
         else
           attributes[:message]
@@ -19,32 +16,30 @@ module ValidationProfiler
       end
 
       def validate(obj, field, attributes = {}, parent = nil)
-
-        #attempt to get the field value from the object
+        # attempt to get the field value from the object
         field_value = get_field_value(obj, field)
 
-        if !is_required?(field_value, attributes)
-          return true
-        end
+        return true unless is_required?(field_value, attributes)
 
         profile = attributes[:profile]
-        if profile == nil
-          raise ValidationProfiler::Exceptions::InvalidValidationRuleAttributes.new(ValidationProfiler::Rules::ChildValidationRule, field)
+        if profile.nil?
+          raise ValidationProfiler::Exceptions::InvalidValidationRuleAttributes
+            .new(ValidationProfiler::Rules::ChildValidationRule, field)
         end
 
-        if field_value == nil
-          return false
-        end
+        return false if field_value.nil?
 
         parent_field = field.to_s
-        if parent != nil
-          parent_field = "#{parent.to_s}.#{field.to_s}"
+        parent_field = "#{parent}.#{field}" unless parent.nil?
+
+        if field_value.is_a? Array
+          result = field_value.map { |value| ValidationProfiler::Manager.new.validate(value, profile, parent_field) }
+        else
+          result = ValidationProfiler::Manager.new.validate(field_value, profile, parent_field)
         end
 
-        return ValidationProfiler::Manager.new.validate(field_value, profile, parent_field)
-
+        result
       end
-
     end
   end
 end

--- a/lib/validation_profiler/rules/child_validation_rule.rb
+++ b/lib/validation_profiler/rules/child_validation_rule.rb
@@ -21,6 +21,7 @@ module ValidationProfiler
 
         return true unless is_required?(field_value, attributes)
         return false if field_value.nil?
+        return false if field_value.respond_to?(:empty?) && field_value.empty?
 
         validation_profile = get_validation_profile(attributes, field)
         parent_field = build_parent_field(parent, field)

--- a/lib/validation_profiler/version.rb
+++ b/lib/validation_profiler/version.rb
@@ -1,5 +1,5 @@
 # Namespace
 module ValidationProfiler
   # :nodoc:
-  VERSION = '1.6.1'.freeze
+  VERSION = '1.7.0'.freeze
 end

--- a/lib/validation_profiler/version.rb
+++ b/lib/validation_profiler/version.rb
@@ -1,5 +1,5 @@
 # Namespace
 module ValidationProfiler
   # :nodoc:
-  VERSION = '1.6.0'.freeze
+  VERSION = '1.6.1'.freeze
 end

--- a/script/docker-compose.yml
+++ b/script/docker-compose.yml
@@ -1,6 +1,6 @@
 gem_test_runner:
-  image: codeguru/ruby:2.3.1-alpine-3.4
+  image: sageone/validation_profiler_test_runner
   container_name: gem_test_runner
   command: bash -c "while true; do echo 'Container is running...'; sleep 2; done"
   volumes:
-      - ../:/gem_src
+      - ../:/validation_profiler

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo setup starting.....
+docker-compose rm
+
+echo build docker image
+cd ../ && docker build --rm -t sageone/validation_profiler_test_runner .
+
+echo setup complete

--- a/script/test.sh
+++ b/script/test.sh
@@ -3,6 +3,4 @@
 echo start rspec tests
 docker-compose up -d
 
-spec_path=spec/$1
-
-docker exec -it gem_test_runner bash -c "cd gem_src && bundle install && bundle exec rspec ${spec_path}"
+docker exec -it gem_test_runner bash -c "bundle install && bundle exec rspec $*"

--- a/spec/test_objects/test_objects.rb
+++ b/spec/test_objects/test_objects.rb
@@ -27,16 +27,20 @@ end
 
 class MultipleRuleTestProfile
   validates :text, :required
-  validates :numeric, :min, { :value => 5 }
+  validates :numeric, :min, { value: 5 }
 end
 
 class MultipleRuleTestProfile2
-  validates :text, :length, {min: 36, max: 36, required: true }
-  validates :numeric, :min, { :value => 5 }
+  validates :text, :length, { min: 36, max: 36, required: true }
+  validates :numeric, :min, { value: 5 }
 end
 
 class ChildRuleTestProfile
   validates :text, :required
-  validates :nested1, :child, { :profile => MultipleRuleTestProfile, :required => true }
-  validates :nested2, :child, { :profile => MultipleRuleTestProfile2, :required => true }
+  validates :nested1, :child, { profile: MultipleRuleTestProfile, required: true }
+  validates :nested2, :child, { profile: MultipleRuleTestProfile2, required: true }
+end
+
+class ChildArrayRuleTestProfile
+  validates :nested, :child, { profile: MultipleRuleTestProfile, required: true }
 end

--- a/spec/validation_profiler/rules/child_validation_rule_spec.rb
+++ b/spec/validation_profiler/rules/child_validation_rule_spec.rb
@@ -40,9 +40,10 @@ RSpec.describe ValidationProfiler::Rules::ChildValidationRule do
       let(:nested_2) { double(text: 'def', numeric: 7) }
       let(:nested_array) { [nested_1, nested_2] }
       let(:hash) { { nested: nested_array } }
+      let(:validation_profile) { MultipleRuleTestProfile }
 
       it 'returns an array of results' do
-        result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile)
+        result = subject.validate(hash, :nested, profile: validation_profile)
 
         expect(result).to be_an(Array)
         expect(result.length).to eq 2
@@ -50,7 +51,7 @@ RSpec.describe ValidationProfiler::Rules::ChildValidationRule do
 
       context 'valid' do
         it 'validates an array of child objects' do
-          result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile)
+          result = subject.validate(hash, :nested, profile: validation_profile)
 
           expect(result[0].outcome).to be true
           expect(result[1].outcome).to be true
@@ -61,10 +62,34 @@ RSpec.describe ValidationProfiler::Rules::ChildValidationRule do
         let(:text) { '' }
 
         it 'validates an array of child objects' do
-          result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile)
+          result = subject.validate(hash, :nested, profile: validation_profile)
 
           expect(result[0].outcome).to be false
           expect(result[1].outcome).to be true
+        end
+      end
+
+      context 'is required' do
+        let(:validation_profile) { ChildArrayRuleTestProfile }
+
+        context 'when empty array' do
+          let(:nested_array) { [] }
+
+          it 'returns false' do
+            result = subject.validate(hash, :nested, profile: validation_profile)
+
+            expect(result).to be false
+          end
+        end
+
+        context 'when nil' do
+          let(:nested_array) { nil }
+
+          it 'returns false' do
+            result = subject.validate(hash, :nested, profile: validation_profile)
+
+            expect(result).to be false
+          end
         end
       end
     end

--- a/spec/validation_profiler/rules/child_validation_rule_spec.rb
+++ b/spec/validation_profiler/rules/child_validation_rule_spec.rb
@@ -1,47 +1,72 @@
 RSpec.describe ValidationProfiler::Rules::ChildValidationRule do
-
   context '#validate' do
-
     it 'should raise an InvalidRuleAttributes exception when a profile attribute is not specified' do
-
-      hash = { :nested => ChildTestObject.new }
-      expect{ subject.validate(hash, :nested, {}) }.to raise_error(ValidationProfiler::Exceptions::InvalidValidationRuleAttributes)
-
+      hash = { nested: ChildTestObject.new }
+      expect { subject.validate(hash, :nested, {}) }
+        .to raise_error(ValidationProfiler::Exceptions::InvalidValidationRuleAttributes)
     end
 
     it 'should fail when the nested object fails validation' do
-
-      hash = { :nested => ChildTestObject.new }
-      result = subject.validate(hash, :nested, { profile: MultipleRuleTestProfile2 })
+      hash = { nested: ChildTestObject.new }
+      result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile2)
       expect(result.outcome).to be false
       expect(result.errors[0][:field]).to eq(:text)
       expect(result.errors[1][:message]).to eq('nested.numeric must have a minimum value of 5')
-
     end
 
     it 'should fail when the nested object fails validation' do
-
       child = ChildTestObject.new
       child.text = 'abcdef'
       child.numeric = 6
-      hash = { :nested => child }
-      result = subject.validate(hash, :nested, { profile: MultipleRuleTestProfile2 })
+      hash = { nested: child }
+      result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile2)
       expect(result.outcome).to be false
       expect(result.errors[0][:field]).to eq(:text)
-
     end
 
     it 'should pass validation when the nested object is valid' do
-
       nested = ChildTestObject.new
-      nested.text= 'abc'
+      nested.text = 'abc'
       nested.numeric = 6
 
-      hash = { :nested => nested }
-      result = subject.validate(hash, :nested, { profile: MultipleRuleTestProfile })
+      hash = { nested: nested }
+      result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile)
       expect(result.outcome).to be true
+    end
 
+    context 'field value is an array' do
+      let(:text) { 'abc' }
+      let(:nested_1) { double(text: text, numeric: 6) }
+      let(:nested_2) { double(text: 'def', numeric: 7) }
+      let(:nested_array) { [nested_1, nested_2] }
+      let(:hash) { { nested: nested_array } }
+
+      it 'returns an array of results' do
+        result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile)
+
+        expect(result).to be_an(Array)
+        expect(result.length).to eq 2
+      end
+
+      context 'valid' do
+        it 'validates an array of child objects' do
+          result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile)
+
+          expect(result[0].outcome).to be true
+          expect(result[1].outcome).to be true
+        end
+      end
+
+      context 'invalid' do
+        let(:text) { '' }
+
+        it 'validates an array of child objects' do
+          result = subject.validate(hash, :nested, profile: MultipleRuleTestProfile)
+
+          expect(result[0].outcome).to be false
+          expect(result[1].outcome).to be true
+        end
+      end
     end
   end
-
 end

--- a/spec/validation_profiler/validation_manager_spec.rb
+++ b/spec/validation_profiler/validation_manager_spec.rb
@@ -1,77 +1,107 @@
 require 'securerandom'
 
 RSpec.describe ValidationProfiler::Manager do
-    it 'should return a pass outcome when an object is valid for the profile' do
-      obj = TestObject.new
-      obj.text = '123456'
-      expect(subject.validate(obj, MinLengthTestProfile).outcome).to eq(true)
-    end
+  it 'should return a pass outcome when an object is valid for the profile' do
+    obj = TestObject.new
+    obj.text = '123456'
+    expect(subject.validate(obj, MinLengthTestProfile).outcome).to eq(true)
+  end
 
-    it 'should return a fail outcome when an object is not valid for the profile' do
-      obj = TestObject.new
-      obj.text = '1234'
-      result = subject.validate(obj, MinLengthTestProfile)
-      expect(result.outcome).to eq(false)
-      expect(result.errors.length).to eq(1)
-    end
+  it 'should return a fail outcome when an object is not valid for the profile' do
+    obj = TestObject.new
+    obj.text = '1234'
+    result = subject.validate(obj, MinLengthTestProfile)
+    expect(result.outcome).to eq(false)
+    expect(result.errors.length).to eq(1)
+  end
 
   it 'should return a pass outcome when an object is valid for the profile' do
-
     obj = TestObject.new
     obj.text = '123456'
     obj.numeric = 6
     expect(subject.validate(obj, MultipleRuleTestProfile).outcome).to eq(true)
-
   end
 
-    it 'should return a fail outcome when an object is not valid for the profile due to :required failing' do
+  it 'should return a fail outcome when an object is not valid for the profile due to :required failing' do
+    obj = TestObject.new
+    obj.text = nil
+    obj.numeric = 6
+    expect(subject.validate(obj, MultipleRuleTestProfile).outcome).to eq(false)
+  end
 
+  context ValidationProfiler::Rules::ChildValidationRule do
+    it 'should fail when a nested property is nil' do
       obj = TestObject.new
-      obj.text = nil
+      obj.text = 'abc'
+      obj.nested1 = nil
+      obj.nested2 = nil
+      manager = ValidationProfiler::Manager.new
+      expect(manager.validate(obj, ChildRuleTestProfile).outcome).to eq(false)
+    end
+
+    it 'should fail when a nested property fails validation' do
+      obj = TestObject.new
+      obj.text = 'abc'
+      obj.nested1 = ChildTestObject.new
+      obj.nested1.text = 'abc'
       obj.numeric = 6
-      expect(subject.validate(obj, MultipleRuleTestProfile).outcome).to eq(false)
-
+      obj.nested2 = ChildTestObject.new
+      obj.nested2.text = SecureRandom.uuid
+      manager = ValidationProfiler::Manager.new
+      result = manager.validate(obj, ChildRuleTestProfile)
+      expect(result.outcome).to eq(false)
+      expect(result.errors.length).to eq(2)
+      expect(result.errors[0][:field]).to eq(:numeric)
     end
 
-    context ValidationProfiler::Rules::ChildValidationRule do
-
-      it 'should fail when a nested property is nil' do
-        obj = TestObject.new
-        obj.text = 'abc'
-        obj.nested1 = nil
-        obj.nested2 = nil
-        manager = ValidationProfiler::Manager.new
-        expect(manager.validate(obj, ChildRuleTestProfile).outcome).to eq(false)
-      end
-
-      it 'should fail when a nested property fails validation' do
-        obj = TestObject.new
-        obj.text = 'abc'
-        obj.nested1 = ChildTestObject.new
-        obj.nested1.text = 'abc'
-        obj.numeric = 6
-        obj.nested2 = ChildTestObject.new
-        obj.nested2.text = SecureRandom.uuid
-        manager = ValidationProfiler::Manager.new
-        result = manager.validate(obj, ChildRuleTestProfile)
-        expect(result.outcome).to eq(false)
-        expect(result.errors.length).to eq(2)
-        expect(result.errors[0][:field]).to eq(:numeric)
-      end
-
-      it 'should pass when a nested property passes validation' do
-        obj = TestObject.new
-        obj.text = 'abc'
-        obj.nested1 = ChildTestObject.new
-        obj.nested1.text = SecureRandom.uuid
-        obj.nested1.numeric = 6
-        obj.nested2 = ChildTestObject.new
-        obj.nested2.text = SecureRandom.uuid
-        obj.nested2.numeric = 6
-        manager = ValidationProfiler::Manager.new
-        result = manager.validate(obj, ChildRuleTestProfile)
-        expect(result.outcome).to eq(true)
-      end
-
+    it 'should pass when a nested property passes validation' do
+      obj = TestObject.new
+      obj.text = 'abc'
+      obj.nested1 = ChildTestObject.new
+      obj.nested1.text = SecureRandom.uuid
+      obj.nested1.numeric = 6
+      obj.nested2 = ChildTestObject.new
+      obj.nested2.text = SecureRandom.uuid
+      obj.nested2.numeric = 6
+      manager = ValidationProfiler::Manager.new
+      result = manager.validate(obj, ChildRuleTestProfile)
+      expect(result.outcome).to eq(true)
     end
+
+    describe 'field value is an array' do
+      let(:text) { SecureRandom.hex(5) }
+      let(:nested_1) { double(text: text, numeric: 6) }
+      let(:nested_2) { double(text: text, numeric: 7) }
+      let(:nested_array) { [nested_1, nested_2] }
+      let(:hash) { { nested: nested_array } }
+
+      context 'valid' do
+        it 'correctly validates an array of child objects' do
+          manager = ValidationProfiler::Manager.new
+          result = manager.validate(hash, ChildArrayRuleTestProfile)
+
+          expect(result.outcome).to eq(true)
+        end
+      end
+
+      context 'invalid' do
+        let(:text) { '' }
+
+        it 'correctly validates an array of child objects' do
+          manager = ValidationProfiler::Manager.new
+          result = manager.validate(hash, ChildArrayRuleTestProfile)
+
+          expect(result.outcome).to eq(false)
+        end
+
+        it 'returns array of validation errors per invalid object' do
+          manager = ValidationProfiler::Manager.new
+          result = manager.validate(hash, ChildArrayRuleTestProfile)
+
+          expect(result.outcome).to eq(false)
+          expect(result.errors.count).to eq 2
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR allows us to validate an array of child objects against a given validation profile.

This will allow us to validate bulk requests to various services including reporting service.