### PR TITLE
Fix issue around validation passing when properties have failed prior to child array validation

### DIFF
--- a/lib/validation_profiler/manager.rb
+++ b/lib/validation_profiler/manager.rb
@@ -21,16 +21,15 @@ module ValidationProfiler
         outcome = rule.validate(obj, r[:field], r[:attributes], parent)
 
         if outcome.is_a?(Array)
-          result.errors = outcome.map(&:errors).flatten
-          result.outcome = result.errors.empty?
+          result.errors += outcome.map(&:errors).flatten
         elsif outcome.is_a?(ValidationProfiler::ManagerResult) && !outcome.outcome
-          result.errors = result.errors + outcome.errors
-          result.outcome = false
+          result.errors += outcome.errors
         elsif !outcome
-          result.outcome = false
           result.errors.push(field: r[:field], message: rule.error_message(r[:field], r[:attributes], parent))
         end
       end
+
+      result.outcome = result.errors.empty?
 
       result
     end

--- a/lib/validation_profiler/version.rb
+++ b/lib/validation_profiler/version.rb
@@ -1,5 +1,5 @@
 # Namespace
 module ValidationProfiler
   # :nodoc:
-  VERSION = '1.7.0'.freeze
+  VERSION = '1.7.1'.freeze
 end

--- a/spec/test_objects/test_objects.rb
+++ b/spec/test_objects/test_objects.rb
@@ -42,5 +42,6 @@ class ChildRuleTestProfile
 end
 
 class ChildArrayRuleTestProfile
+  validates :identifier, :guid, required: true
   validates :nested, :child, { profile: MultipleRuleTestProfile, required: true }
 end

--- a/spec/validation_profiler/validation_manager_spec.rb
+++ b/spec/validation_profiler/validation_manager_spec.rb
@@ -69,11 +69,12 @@ RSpec.describe ValidationProfiler::Manager do
     end
 
     describe 'field value is an array' do
+      let(:identifier) { SecureRandom.uuid.delete('-') }
       let(:text) { SecureRandom.hex(5) }
       let(:nested_1) { double(text: text, numeric: 6) }
       let(:nested_2) { double(text: text, numeric: 7) }
       let(:nested_array) { [nested_1, nested_2] }
-      let(:hash) { { nested: nested_array } }
+      let(:hash) { { identifier: identifier, nested: nested_array } }
 
       context 'valid' do
         it 'correctly validates an array of child objects' do
@@ -81,6 +82,18 @@ RSpec.describe ValidationProfiler::Manager do
           result = manager.validate(hash, ChildArrayRuleTestProfile)
 
           expect(result.outcome).to eq(true)
+        end
+
+        context 'but a property has failed validation' do
+          let(:identifier) { '' }
+
+          it 'fails validation' do
+            manager = ValidationProfiler::Manager.new
+            result = manager.validate(hash, ChildArrayRuleTestProfile)
+
+            expect(result.outcome).to eq(false)
+            expect(result.errors.count).to eq(1)
+          end
         end
       end
 
@@ -100,6 +113,18 @@ RSpec.describe ValidationProfiler::Manager do
 
           expect(result.outcome).to eq(false)
           expect(result.errors.count).to eq 2
+        end
+
+        context 'and a previous property has failed validation' do
+          let(:identifier) { '' }
+
+          it 'fails validation and returns all errors' do
+            manager = ValidationProfiler::Manager.new
+            result = manager.validate(hash, ChildArrayRuleTestProfile)
+
+            expect(result.outcome).to eq(false)
+            expect(result.errors.count).to eq 3
+          end
         end
       end
     end


### PR DESCRIPTION
This PR provides a fix on the back of the introduction of validation for an array of child objects.

Currently if a property fails validation before a successful validation of an array of child objects then the manager would return true, indicating that the validation of the object as a whole has succeeded, yet it has not passed for all properties.