### PR TITLE
Change decimal validation to accept BigDecimal

### DIFF
--- a/lib/validation_profiler/rules/decimal_validation_rule.rb
+++ b/lib/validation_profiler/rules/decimal_validation_rule.rb
@@ -29,7 +29,7 @@ module ValidationProfiler
           return true
         end
 
-        if !is_valid_decimal?(field_value.to_s)
+        if !is_valid_decimal?(field_value)
           return false
         end
 
@@ -38,9 +38,12 @@ module ValidationProfiler
       end
 
       def is_valid_decimal?(value)
-        (value =~ /\A[-+]?\d*\.?\d+\z/) == 0
+        if value.instance_of? BigDecimal
+          true
+        else
+          (value.to_s =~ /\A[-+]?\d*\.?\d+\z/) == 0
+        end
       end
-
     end
   end
 end

--- a/spec/validation_profiler/rules/decimal_validation_rule_spec.rb
+++ b/spec/validation_profiler/rules/decimal_validation_rule_spec.rb
@@ -21,6 +21,12 @@ RSpec.describe ValidationProfiler::Rules::DecimalValidationRule do
           expect(subject.validate(obj, :decimal)).to eq(true)
         end
       end
+      context 'that is a BigDecimal' do
+        it 'should return true' do
+          obj = { decimal: BigDecimal('12.50') }
+          expect(subject.validate(obj, :decimal)).to eq(true)
+        end
+      end
     end
 
     context 'when an invalid decimal is specified' do


### PR DESCRIPTION
This PR is to support the change of using BigDecimal instead of Float in Reporting Service (Nominal Activity/Stock Movements). 

https://jira.sage.com/browse/SI-1336