### PR TITLE
Allow using custom validation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,13 +484,13 @@ class RequiredValidationRule < ValidationRule
       #return custom message
       attributes[:message]
     end
-end
+  end
 
-def validate(obj, field, attributes = {})
-  #attempt to get the field value from the object
-  field_value = get_field_value(obj, field)
+  def validate(obj, field, attributes = {})
+    #attempt to get the field value from the object
+    field_value = get_field_value(obj, field)
 
-  if field_value == nil
+    if field_value == nil
       return false
     end
 
@@ -500,6 +500,13 @@ end
 ```
 
 The **ValidationRule** base class provides the `#get_field_value(obj, field)` method to cater for fetching the field value from the object to perform the validation against.
+
+This rule can be added to the ValidationProfiler::Manager, e.g.:
+
+```ruby
+validation_manager = ValidationProfiler::Manager.new
+validation_manager.add_rule(:custom_required, RequiredValidationRule)
+```
 
 ## Development
 

--- a/lib/validation_profiler/manager.rb
+++ b/lib/validation_profiler/manager.rb
@@ -33,5 +33,17 @@ module ValidationProfiler
 
       result
     end
+
+    # Called to add a custom validation rule to the manager
+    #
+    # @param key [Symbol] The name of the rule
+    # @param rule [ClassName] Class name of the validation rule to register.
+    def add_rule(key, rule)
+      if ValidationProfiler::Rules::Manager.instance.nil?
+        ValidationProfiler::Rules::Manager.new
+      end
+
+      ValidationProfiler::Rules::Manager.instance.add_rule(key, rule)
+    end
   end
 end

--- a/spec/test_objects/test_objects.rb
+++ b/spec/test_objects/test_objects.rb
@@ -25,6 +25,10 @@ class CustomRequiredValidationRule < ValidationProfiler::Rules::RequiredValidati
 
 end
 
+class CustomRuleTestProfile
+  validates :text, :custom_required
+end
+
 class MultipleRuleTestProfile
   validates :text, :required
   validates :numeric, :min, { value: 5 }

--- a/spec/validation_profiler/rules/max_validation_rule_spec.rb
+++ b/spec/validation_profiler/rules/max_validation_rule_spec.rb
@@ -28,6 +28,12 @@ RSpec.describe ValidationProfiler::Rules::MaxValidationRule do
       expect(subject.validate(test_obj, :datetime, { value: DateTime.now })).to eq(false)
     end
 
+    it 'should fail to validate if the field is not a numeric or datetime type' do
+      test_obj = TestObject.new
+      test_obj.datetime = 'test'
+      expect { subject.validate(test_obj, :datetime, { value: DateTime.now }) }.to raise_error(ValidationProfiler::Exceptions::InvalidFieldType)
+    end
+
   end
 
   describe '#error_message' do

--- a/spec/validation_profiler/validation_manager_spec.rb
+++ b/spec/validation_profiler/validation_manager_spec.rb
@@ -29,6 +29,15 @@ RSpec.describe ValidationProfiler::Manager do
     expect(subject.validate(obj, MultipleRuleTestProfile).outcome).to eq(false)
   end
 
+  context '#add_rule'  do
+    it 'should add a valid rule and use it to validate' do
+      manager = ValidationProfiler::Manager.new
+      manager.add_rule(:custom_required, CustomRequiredValidationRule)
+      expect(manager.validate(TestObject.new, CustomRuleTestProfile).outcome).to eq(false)
+    end
+
+  end
+
   context ValidationProfiler::Rules::ChildValidationRule do
     it 'should fail when a nested property is nil' do
       obj = TestObject.new

--- a/spec/validation_profiler/validation_manager_spec.rb
+++ b/spec/validation_profiler/validation_manager_spec.rb
@@ -36,6 +36,11 @@ RSpec.describe ValidationProfiler::Manager do
       expect(manager.validate(TestObject.new, CustomRuleTestProfile).outcome).to eq(false)
     end
 
+    it 'will instantiate a rules manager instance if it is not set' do
+      ValidationProfiler::Rules::Manager.instance = nil
+      subject.add_rule(:custom_required, CustomRequiredValidationRule)
+      expect(ValidationProfiler::Rules::Manager.instance).not_to be_nil
+    end
   end
 
   context ValidationProfiler::Rules::ChildValidationRule do


### PR DESCRIPTION
Exposes a method to add rules to a validation manager without having to rely on knowing implementation details / monkeypatching.